### PR TITLE
Fix property name for material in fotovoltaico schema

### DIFF
--- a/src/utils/schemas/schema-fotovoltaico.ts
+++ b/src/utils/schemas/schema-fotovoltaico.ts
@@ -23,7 +23,7 @@ const localInstalacaoModuloDTOSchema = baseDTOSchema.shape({
 });
 
 const materialVigasTelhadoDTOSchema = baseDTOSchema.shape({
-  condicao: yup.string().optional(), // ✅ Correção aqui
+  material: yup.string().optional(),
 });
 
 const modeloRelogioDTOSchema = baseDTOSchema.shape({


### PR DESCRIPTION
## Summary
- update `materialVigasTelhadoDTOSchema` to use `material` property

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684057a8dac4832eb9be1536b091cf31