### PR TITLE
Fix form field names to match validation schema

### DIFF
--- a/src/redux/reducers/fotovoltaico-reducer.ts
+++ b/src/redux/reducers/fotovoltaico-reducer.ts
@@ -10,7 +10,7 @@ export type CondicaoDTO = BaseDTO & { condicao?: string };
 export type IdadeTelhadoDTO = BaseDTO & { idade?: number };
 export type NivelamentoSoloDTO = BaseDTO & { nivelamento?: string };
 export type LocalInstalacaoModuloDTO = BaseDTO & { local?: string };
-export type MaterialVigasTelhadoDTO = BaseDTO & { material?: string };
+export type MaterialVigasTelhadoDTO = BaseDTO & { condicao?: string };
 export type ModeloRelogioDTO = BaseDTO & { modelo?: string };
 export type TelhadoAcessoDTO = BaseDTO & { acesso?: string };
 export type TensaoNominalDTO = BaseDTO & { tensao?: string };
@@ -68,7 +68,7 @@ export type FotovoltaicoTS = {
 	nivelamentoSoloDTO?: NivelamentoSoloDTO;
 	telhadoAcessoDTO?: TelhadoAcessoDTO;
 	tensaoNominalDTO?: TensaoNominalDTO;
-	tipoidClienteNavigation?: TipoDTO;
+        tipoClienteDTO?: TipoDTO;
 	tipoLigacaoDTO?: TipoDTO;
 	tipoSuperficieDTO?: TipoDTO;
 };
@@ -104,7 +104,7 @@ export const fotovoltaicoSlice = createSlice({
 			if (payload.bitolaCondutorPe !== undefined) state.bitolaCondutorPe = payload.bitolaCondutorPe;
 			
 			// DTOs
-			if (payload.tipoidClienteNavigation) state.tipoidClienteNavigation = safeAssign(state.tipoidClienteNavigation, payload.tipoidClienteNavigation);
+                        if (payload.tipoClienteDTO) state.tipoClienteDTO = safeAssign(state.tipoClienteDTO, payload.tipoClienteDTO);
 			if (payload.tipoLigacaoDTO) state.tipoLigacaoDTO = safeAssign(state.tipoLigacaoDTO, payload.tipoLigacaoDTO);
 			if (payload.tensaoNominalDTO) state.tensaoNominalDTO = safeAssign(state.tensaoNominalDTO, payload.tensaoNominalDTO);
 			if (payload.condicaoPadraoEntradaDTO) state.condicaoPadraoEntradaDTO = safeAssign(state.condicaoPadraoEntradaDTO, payload.condicaoPadraoEntradaDTO);

--- a/src/screens/Fotovoltaico/InstalacaoModuloForm/index.tsx
+++ b/src/screens/Fotovoltaico/InstalacaoModuloForm/index.tsx
@@ -124,10 +124,10 @@ const InstalacaoModuloForm = ({
 			</FormFieldsContainer>
 
 			<FormFieldsContainer>
-				<Label>Material das Vigas do Telhado</Label>
-				<Controller
-					control={control}
-					name="materialVigasTelhadoDTO.material"
+                                <Label>Material das Vigas do Telhado</Label>
+                                <Controller
+                                        control={control}
+                                        name="materialVigasTelhadoDTO.condicao"
 					render={({ field: { onChange, value } }) => (
 						<Input.Root>
 							<Input.Input
@@ -135,9 +135,9 @@ const InstalacaoModuloForm = ({
 								placeholderText="ex.: Madeira, Metal"
 								onChange={onChange}
 							/>
-							<Input.ErrorText
-								ErrorText={errors.materialVigasTelhadoDTO?.message}
-							/>
+                                                        <Input.ErrorText
+                                                                ErrorText={errors.materialVigasTelhadoDTO?.condicao?.message}
+                                                        />
 						</Input.Root>
 					)}
 				/>

--- a/src/screens/Fotovoltaico/PadraoEntradaForm/index.tsx
+++ b/src/screens/Fotovoltaico/PadraoEntradaForm/index.tsx
@@ -87,9 +87,9 @@ const PadraoEntradaForm = ({ control, errors }: PadraoEntradaFormProps) => {
 		<View>
 			<FormFieldsContainer>
 				<Label>Concessionária de Energia</Label>
-				<Controller
-					control={control}
-					name="concessionariaEnergia"
+                                <Controller
+                                        control={control}
+                                        name="concessionariaEnergiaPe"
 					render={({ field: { onChange, value } }) => (
 						<Input.Root>
 							<Input.Input
@@ -97,37 +97,37 @@ const PadraoEntradaForm = ({ control, errors }: PadraoEntradaFormProps) => {
 								placeholderText="ex.: ABC Electric"
 								onChange={onChange}
 							/>
-							<Input.ErrorText
-								ErrorText={errors.concessionariaEnergia?.message}
-							/>
+                                                        <Input.ErrorText
+                                                                ErrorText={errors.concessionariaEnergiaPe?.message}
+                                                        />
 						</Input.Root>
 					)}
 				/>
 			</FormFieldsContainer>
 
 			<FormFieldsContainer>
-				<Label>Tipo de Cliente</Label>
-				<Controller
-					control={control}
-					name="tipoidClienteNavigation"
-					render={({ field: { onChange, value } }) => (
-						<Input.Root>
-							<Input.Input
-								value={value || ""}
-								placeholderText="ex.: Residencial, Comercial"
-								onChange={(newValue) => onChange({ tipo: newValue })}
-							/>
-							<Input.ErrorText ErrorText={errors.tipoidClienteNavigation?.message} />
-						</Input.Root>
-					)}
-				/>
+                                <Label>Tipo de Cliente</Label>
+                                <Controller
+                                        control={control}
+                                        name="tipoClienteDTO.tipo"
+                                        render={({ field: { onChange, value } }) => (
+                                                <Input.Root>
+                                                        <Input.Input
+                                                                value={value || ""}
+                                                                placeholderText="ex.: Residencial, Comercial"
+                                                                onChange={onChange}
+                                                        />
+                                                        <Input.ErrorText ErrorText={errors.tipoClienteDTO?.tipo?.message} />
+                                                </Input.Root>
+                                        )}
+                                />
 			</FormFieldsContainer>
 
 			<FormFieldsContainer>
-				<Label>Demanda Contratada</Label>
-				<Controller
-					control={control}
-					name="demandaContratada"
+                                <Label>Demanda Contratada</Label>
+                                <Controller
+                                        control={control}
+                                        name="demandaContratadaPe"
 					render={({ field: { onChange, value } }) => (
 						<Input.Root>
 							<Input.Input
@@ -135,73 +135,73 @@ const PadraoEntradaForm = ({ control, errors }: PadraoEntradaFormProps) => {
 								placeholderText="ex.: 100kW"
 								onChange={onChange}
 							/>
-							<Input.ErrorText ErrorText={errors.demandaContratada?.message} />
+                                                        <Input.ErrorText ErrorText={errors.demandaContratadaPe?.message} />
 						</Input.Root>
 					)}
 				/>
 			</FormFieldsContainer>
 
 			<FormFieldsContainer>
-				<Label>Tipo de Ligação</Label>
-				<Controller
-					control={control}
-					name="tipoLigacaoDTO"
-					render={({ field: { onChange, value } }) => (
-						<Input.Root>
-							<Input.Input
-								value={value || ""}
-								placeholderText="ex.: Monofásica, Bifásica, Trifásica"
-								onChange={(newValue) => onChange({ tipo: newValue })}
-							/>
-							<Input.ErrorText ErrorText={errors.tipoLigacaoDTO?.message} />
-						</Input.Root>
-					)}
-				/>
+                                <Label>Tipo de Ligação</Label>
+                                <Controller
+                                        control={control}
+                                        name="tipoLigacaoDTO.tipo"
+                                        render={({ field: { onChange, value } }) => (
+                                                <Input.Root>
+                                                        <Input.Input
+                                                                value={value || ""}
+                                                                placeholderText="ex.: Monofásica, Bifásica, Trifásica"
+                                                                onChange={onChange}
+                                                        />
+                                                        <Input.ErrorText ErrorText={errors.tipoLigacaoDTO?.tipo?.message} />
+                                                </Input.Root>
+                                        )}
+                                />
 			</FormFieldsContainer>
 
 			<FormFieldsContainer>
-				<Label>Tensão Nominal</Label>
-				<Controller
-					control={control}
-					name="tensaoNominalDTO"
-					render={({ field: { onChange, value } }) => (
-						<Input.Root>
-							<Input.Input
-								value={value || ""}
-								placeholderText="ex.: 220V, 380V"
-								onChange={(newValue) => onChange({ tensao: newValue })}
-							/>
-							<Input.ErrorText ErrorText={errors.tensaoNominalDTO?.message} />
-						</Input.Root>
-					)}
-				/>
+                                <Label>Tensão Nominal</Label>
+                                <Controller
+                                        control={control}
+                                        name="tensaoNominalDTO.tensao"
+                                        render={({ field: { onChange, value } }) => (
+                                                <Input.Root>
+                                                        <Input.Input
+                                                                value={value || ""}
+                                                                placeholderText="ex.: 220V, 380V"
+                                                                onChange={onChange}
+                                                        />
+                                                        <Input.ErrorText ErrorText={errors.tensaoNominalDTO?.tensao?.message} />
+                                                </Input.Root>
+                                        )}
+                                />
 			</FormFieldsContainer>
 
 			<FormFieldsContainer>
-				<Label>Condição Padrão de Entrada</Label>
-				<Controller
-					control={control}
-					name="condicaoPadraoEntradaDTO"
-					render={({ field: { onChange, value } }) => (
-						<Input.Root>
-							<Input.Input
-								value={value || ""}
-								placeholderText="ex.: Bom, Regular, Ruim"
-								onChange={(newValue) => onChange({ condicao: newValue })}
-							/>
-							<Input.ErrorText
-								ErrorText={errors.condicaoPadraoEntradaDTO?.message}
-							/>
-						</Input.Root>
-					)}
-				/>
+                                <Label>Condição Padrão de Entrada</Label>
+                                <Controller
+                                        control={control}
+                                        name="condicaoPadraoEntradaDTO.condicao"
+                                        render={({ field: { onChange, value } }) => (
+                                                <Input.Root>
+                                                        <Input.Input
+                                                                value={value || ""}
+                                                                placeholderText="ex.: Bom, Regular, Ruim"
+                                                                onChange={onChange}
+                                                        />
+                                                        <Input.ErrorText
+                                                                ErrorText={errors.condicaoPadraoEntradaDTO?.condicao?.message}
+                                                        />
+                                                </Input.Root>
+                                        )}
+                                />
 			</FormFieldsContainer>
 
 			<FormFieldsContainer>
-				<Label>Dimensão da Caixa Padrão</Label>
-				<Controller
-					control={control}
-					name="dimensaoCaixaPadrao"
+                                <Label>Dimensão da Caixa Padrão</Label>
+                                <Controller
+                                        control={control}
+                                        name="dimensaoCaixaPadraoPe"
 					render={({ field: { onChange, value } }) => (
 						<Input.Root>
 							<Input.Input
@@ -209,30 +209,30 @@ const PadraoEntradaForm = ({ control, errors }: PadraoEntradaFormProps) => {
 								placeholderText="ex.: 60x40x20cm"
 								onChange={onChange}
 							/>
-							<Input.ErrorText
-								ErrorText={errors.dimensaoCaixaPadrao?.message}
-							/>
+                                                        <Input.ErrorText
+                                                                ErrorText={errors.dimensaoCaixaPadraoPe?.message}
+                                                        />
 						</Input.Root>
 					)}
 				/>
 			</FormFieldsContainer>
 
 			<FormFieldsContainer>
-				<Label>Modelo do Relógio</Label>
-				<Controller
-					control={control}
-					name="modeloRelogioDTO"
-					render={({ field: { onChange, value } }) => (
-						<Input.Root>
-							<Input.Input
-								value={value || ""}
-								placeholderText="ex.: ABC123"
-								onChange={(newValue) => onChange({ modelo: newValue })}
-							/>
-							<Input.ErrorText ErrorText={errors.modeloRelogioDTO?.message} />
-						</Input.Root>
-					)}
-				/>
+                                <Label>Modelo do Relógio</Label>
+                                <Controller
+                                        control={control}
+                                        name="modeloRelogioDTO.modelo"
+                                        render={({ field: { onChange, value } }) => (
+                                                <Input.Root>
+                                                        <Input.Input
+                                                                value={value || ""}
+                                                                placeholderText="ex.: ABC123"
+                                                                onChange={onChange}
+                                                        />
+                                                        <Input.ErrorText ErrorText={errors.modeloRelogioDTO?.modelo?.message} />
+                                                </Input.Root>
+                                        )}
+                                />
 			</FormFieldsContainer>
 		</View>
 	);

--- a/src/screens/Fotovoltaico/QuadroPrincipalForm/index.tsx
+++ b/src/screens/Fotovoltaico/QuadroPrincipalForm/index.tsx
@@ -124,12 +124,12 @@ const QuadroPrincipalForm = ({ control, errors }: QuadroPrincipalFormProps) => {
 			</FormFieldsContainer>
 
 			<FormFieldsContainer>
-				<Label>
-					Bitola do Condutor de Entrada no Quadro (Antes do Disjuntor Geral)
-				</Label>
-				<Controller
-					control={control}
-					name="bitolaCondutorEntradaQuadro"
+                                <Label>
+                                        Bitola do Condutor de Entrada no Quadro (Antes do Disjuntor Geral)
+                                </Label>
+                                <Controller
+                                        control={control}
+                                        name="antesDisjuntorPe"
 					render={({ field: { onChange, value } }) => (
 						<Input.Root>
 							<Input.Input
@@ -137,19 +137,19 @@ const QuadroPrincipalForm = ({ control, errors }: QuadroPrincipalFormProps) => {
 								placeholderText="ex.: 10mm²"
 								onChange={onChange}
 							/>
-							<Input.ErrorText
-								ErrorText={errors.bitolaCondutorEntradaQuadro?.message}
-							/>
+                                                        <Input.ErrorText
+                                                                ErrorText={errors.antesDisjuntorPe?.message}
+                                                        />
 						</Input.Root>
 					)}
 				/>
 			</FormFieldsContainer>
 
 			<FormFieldsContainer>
-				<Label>Aterramento</Label>
-				<Controller
-					control={control}
-					name="aterramentoQpe"
+                                <Label>Aterramento</Label>
+                                <Controller
+                                        control={control}
+                                        name="aterramentoPe"
 					render={({ field: { onChange, value } }) => (
 						<Input.Root>
 							<Input.Input
@@ -157,10 +157,10 @@ const QuadroPrincipalForm = ({ control, errors }: QuadroPrincipalFormProps) => {
 								placeholderText="ex.: Sim, Não"
 								onChange={onChange}
 							/>
-							<Input.ErrorText ErrorText={errors.aterramentoQpe?.message} />
-						</Input.Root>
-					)}
-				/>
+                                                        <Input.ErrorText ErrorText={errors.aterramentoPe?.message} />
+                                                </Input.Root>
+                                        )}
+                                />
 			</FormFieldsContainer>
 		</View>
 	);

--- a/src/screens/Fotovoltaico/SoloForm/index.tsx
+++ b/src/screens/Fotovoltaico/SoloForm/index.tsx
@@ -83,76 +83,78 @@ const SoloForm = ({ control, errors }: SoloFormProps) => {
 	return (
 		<View>
 			<FormFieldsContainer>
-				<Label>Tipo de Solo</Label>
-				<Controller
-					control={control}
-					name="tipoSolo"
-					render={({ field: { onChange, value } }) => (
-						<Input.Root>
-							<Input.Input
-								value={value || ""}
-								placeholderText="ex.: Areia, Argila"
-								onChange={onChange}
-							/>
-							<Input.ErrorText ErrorText={errors.tipoSolo?.message} />
-						</Input.Root>
-					)}
-				/>
-			</FormFieldsContainer>
+                                <Label>Largura do Solo (m)</Label>
+                                <Controller
+                                        control={control}
+                                        name="larguraSolo"
+                                        render={({ field: { onChange, value } }) => (
+                                                <Input.Root>
+                                                        <Input.Input
+                                                                value={value?.toString() || ""}
+                                                                placeholderText="ex.: 1.5"
+                                                                onChange={onChange}
+                                                                keyboardType="numeric"
+                                                        />
+                                                        <Input.ErrorText ErrorText={errors.larguraSolo?.message} />
+                                                </Input.Root>
+                                        )}
+                                />
+                        </FormFieldsContainer>
 
-			<FormFieldsContainer>
-				<Label>Condiciones do Solo</Label>
-				<Controller
-					control={control}
-					name="condicaoSolo"
-					render={({ field: { onChange, value } }) => (
-						<Input.Root>
-							<Input.Input
-								value={value || ""}
-								placeholderText="ex.: Bom, Regular, Ruim"
-								onChange={onChange}
-							/>
-							<Input.ErrorText ErrorText={errors.condicaoSolo?.message} />
-						</Input.Root>
-					)}
-				/>
-			</FormFieldsContainer>
+                        <FormFieldsContainer>
+                                <Label>Comprimento do Solo (m)</Label>
+                                <Controller
+                                        control={control}
+                                        name="comprimentoSolo"
+                                        render={({ field: { onChange, value } }) => (
+                                                <Input.Root>
+                                                        <Input.Input
+                                                                value={value?.toString() || ""}
+                                                                placeholderText="ex.: 5.0"
+                                                                onChange={onChange}
+                                                                keyboardType="numeric"
+                                                        />
+                                                        <Input.ErrorText ErrorText={errors.comprimentoSolo?.message} />
+                                                </Input.Root>
+                                        )}
+                                />
+                        </FormFieldsContainer>
 
-			<FormFieldsContainer>
-				<Label>Presença de Rocha</Label>
-				<Controller
-					control={control}
-					name="presencaRocha"
-					render={({ field: { onChange, value } }) => (
-						<Input.Root>
-							<Input.Input
-								value={value || ""}
-								placeholderText="ex.: Sim, Não"
-								onChange={onChange}
-							/>
-							<Input.ErrorText ErrorText={errors.presencaRocha?.message} />
-						</Input.Root>
-					)}
-				/>
-			</FormFieldsContainer>
+                        <FormFieldsContainer>
+                                <Label>Nivelamento do Solo</Label>
+                                <Controller
+                                        control={control}
+                                        name="nivelamentoSoloDTO.nivelamento"
+                                        render={({ field: { onChange, value } }) => (
+                                                <Input.Root>
+                                                        <Input.Input
+                                                                value={value || ""}
+                                                                placeholderText="ex.: Plano, Irregular"
+                                                                onChange={onChange}
+                                                        />
+                                                        <Input.ErrorText ErrorText={errors.nivelamentoSoloDTO?.nivelamento?.message} />
+                                                </Input.Root>
+                                        )}
+                                />
+                        </FormFieldsContainer>
 
-			<FormFieldsContainer>
-				<Label>Profundidade do Solo</Label>
-				<Controller
-					control={control}
-					name="profundidadeSolo"
-					render={({ field: { onChange, value } }) => (
-						<Input.Root>
-							<Input.Input
-								value={value || ""}
-								placeholderText="ex.: 1.5m"
-								onChange={onChange}
-							/>
-							<Input.ErrorText ErrorText={errors.profundidadeSolo?.message} />
-						</Input.Root>
-					)}
-				/>
-			</FormFieldsContainer>
+                        <FormFieldsContainer>
+                                <Label>Tipo de Superfície</Label>
+                                <Controller
+                                        control={control}
+                                        name="tipoSuperficieDTO.tipo"
+                                        render={({ field: { onChange, value } }) => (
+                                                <Input.Root>
+                                                        <Input.Input
+                                                                value={value || ""}
+                                                                placeholderText="ex.: Terra, Concreto"
+                                                                onChange={onChange}
+                                                        />
+                                                        <Input.ErrorText ErrorText={errors.tipoSuperficieDTO?.tipo?.message} />
+                                                </Input.Root>
+                                        )}
+                                />
+                        </FormFieldsContainer>
 		</View>
 	);
 };


### PR DESCRIPTION
## Summary
- align reducer types with schema
- update PadraoEntrada form fields to match schema names
- update QuadroPrincipal field names
- fix SoloForm fields for ground dimensions
- correct InstalacaoModuloForm property for roof beam material

## Testing
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68407904db04832e9ef2e9a2c964d2b0